### PR TITLE
fix temp js expression and initworkdir files

### DIFF
--- a/mariner/TECHDEBT.md
+++ b/mariner/TECHDEBT.md
@@ -1,0 +1,13 @@
+# Tech Debt
+
+### resolveExpression ${} parsing
+
+Created: 9/30/2021
+
+Issue: right now we are not able to parse a combination of ${} and $() expressions. We are only able to parse either only ${} or $()
+
+Why this occured: This was a stopgap to get the pre genesis workflow working, previosuly mariner did not support evaluation of ${} expressions
+
+Imapct: We won't be able to correctly parse and evaluate for example ${....} .... $()
+
+Planned Resolution: As part of PXP-8786, we will refactor how js expressions are evaluated and will fix this issue.

--- a/mariner/engine.go
+++ b/mariner/engine.go
@@ -63,6 +63,8 @@ type Tool struct {
 	ExpressionResult map[string]interface{}
 	Task             *Task
 	S3Input          *ToolS3Input
+	userFiles        []string
+	commonsUID       []string
 
 	// dev'ing
 	// need to load this with runtime context as per CWL spec

--- a/mariner/k8s.go
+++ b/mariner/k8s.go
@@ -271,8 +271,18 @@ func (tool *Tool) env() (env []k8sv1.EnvVar, err error) {
 
 // for marinerTask job
 func (engine *K8sEngine) s3SidecarEnv(tool *Tool) (env []k8sv1.EnvVar) {
+	userFiles := strings.Join(tool.userFiles, ",")
+	commonsUIDs := strings.Join(tool.commonsUID, ",")
 	engine.infof("load s3 sidecar env for task: %v", tool.Task.Root.ID)
 	env = []k8sv1.EnvVar{
+		{
+			Name:  "UserFiles",
+			Value: userFiles,
+		},
+		{
+			Name:  "CommonsUIDs",
+			Value: commonsUIDs,
+		},
 		{
 			Name:  "IsInitWorkDir",
 			Value: engine.IsInitWorkDir,

--- a/mariner/server.go
+++ b/mariner/server.go
@@ -528,11 +528,11 @@ func (server *Server) fetchRefreshToken() bool {
 		authUrl := wtsPath + "authorization_url?redirect=/"
 		res, err := http.Get(authUrl)
 		if err != nil {
-			fmt.Println("error fetching refresh token from wts")
+			logrus.Info("error fetching refresh token from wts")
 			return false
 		}
 		if res.StatusCode == 400 {
-			fmt.Println("wts refresh token bad request, user error")
+			logrus.Info("wts refresh token bad request, user error")
 			return false
 		}
 		res.Body.Close()


### PR DESCRIPTION
Jira Ticket: [PXP-8788](https://ctds-planx.atlassian.net/browse/PXP-8788) [PXP-8788](https://ctds-planx.atlassian.net/browse/PXP-8786) 

### Bug fix

1. Right now initworkdir will put all commons and user files into the working directory, this PR will fix that issue
2. We are adding a temp fix for {} expression evaluation in javascript

