### PR TITLE
Feat - get metadata for commons files

### DIFF
--- a/mariner/config.go
+++ b/mariner/config.go
@@ -43,6 +43,8 @@ const (
 	commonsPrefix     = "COMMONS/"
 	userPrefix        = "USER/"
 	conformancePrefix = "CONFORMANCE/"
+	workspacePrefix   = "/" + engineWorkspaceVolumeName
+	gatewayPrefix     = "/" + commonsDataVolumeName
 
 	notStarted = "not-started" // 3
 	running    = "running"     // 2
@@ -109,7 +111,7 @@ const (
 	pathToUserRunsf   = "%v/workflowRuns/"                // fill with userID
 	pathToUserRunLogf = pathToUserRunsf + "%v/" + logFile // fill with runID
 
-	commonsDataPersistentVolumeClaimName = "mariner-nfs-pvc"
+	commonsDataPersistentVolumeClaimName = "nfs-commons-data-test-pvc"
 )
 
 var (

--- a/mariner/engine.go
+++ b/mariner/engine.go
@@ -42,7 +42,6 @@ type K8sEngine struct {
 	Manifest        *Manifest           // to pass the manifest to the gen3fuse container of each task pod
 	Log             *MainLog            //
 	KeepFiles       map[string]bool     // all the paths to not delete during basic file cleanup
-	IsInitWorkDir   string
 }
 
 // Tool represents a leaf in the graph of a workflow
@@ -63,7 +62,6 @@ type Tool struct {
 	ExpressionResult map[string]interface{}
 	Task             *Task
 	S3Input          []*ToolS3Input
-	initWorkDirFiles []string
 
 	// dev'ing
 	// need to load this with runtime context as per CWL spec
@@ -84,9 +82,9 @@ type TaskRuntimeJSContext struct {
 
 // ToolS3Input ..
 type ToolS3Input struct {
-	URL         string `json:"url"`            // S3 URL
-	Path        string `json:"path"`           // Local path for dl
-	InitWorkDir bool   `json:"init_work_dir"`  // is this an initwkdir requirement?
+	URL         string `json:"url"`           // S3 URL
+	Path        string `json:"path"`          // Local path for dl
+	InitWorkDir bool   `json:"init_work_dir"` // is this an initwkdir requirement?
 }
 
 // Engine runs an instance of the mariner engine job
@@ -283,7 +281,7 @@ func (task *Task) tool(runID string) *Tool {
 	tool := &Tool{
 		Task:       task,
 		WorkingDir: task.workingDir(runID),
-		S3Input: []*ToolS3Input{},
+		S3Input:    []*ToolS3Input{},
 	}
 	tool.JSVM = tool.newJSVM()
 	task.infof("end make tool object")

--- a/mariner/k8s.go
+++ b/mariner/k8s.go
@@ -271,17 +271,8 @@ func (tool *Tool) env() (env []k8sv1.EnvVar, err error) {
 
 // for marinerTask job
 func (engine *K8sEngine) s3SidecarEnv(tool *Tool) (env []k8sv1.EnvVar) {
-	initWorkDirFiles := strings.Join(tool.initWorkDirFiles, ",")
 	engine.infof("load s3 sidecar env for task: %v", tool.Task.Root.ID)
 	env = []k8sv1.EnvVar{
-		{
-			Name:  "InitWorkDirFiles",
-			Value: initWorkDirFiles,
-		},
-		{
-			Name:  "IsInitWorkDir",
-			Value: engine.IsInitWorkDir,
-		},
 		{
 			Name:      "AWSCREDS",
 			ValueFrom: envVarAWSUserCreds,


### PR DESCRIPTION
This was originally opened to use the indexd method to get metadata as described in PXP-8902 but we were able to get around this by using a different kind of path.

- handle `/commons-data/` paths in init workdir
- fix some logic in sidecar for staging files